### PR TITLE
Replace $.extend with WHS.API.extend

### DIFF
--- a/src/Controls/FPSControls.js
+++ b/src/Controls/FPSControls.js
@@ -16,7 +16,7 @@ WHS.init.prototype.MakeFirstPerson = function(object, params) {
 
     'use strict';
 
-    var target = $.extend({
+    var target = WHS.API.extend({
         block: $('#blocker'),
         speed: 1,
         ypos: 1


### PR DESCRIPTION
$.extend overwrites the values given by the user .