### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
     "dev": "gulp dev",
     "lint": "gulp src:lint"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/WhitestormJS/whitestorm.js.git"
-  },
+  "repository": "WhitestormJS/whitestorm.js",
   "keywords": [
     "whitestorm.js",
     "three.js",
@@ -30,9 +27,6 @@
   ],
   "author": "Alexander Buzin",
   "license": "CC",
-  "bugs": {
-    "url": "https://github.com/WhitestormJS/whitestorm.js/issues"
-  },
   "homepage": "https://github.com/WhitestormJS/whitestorm.js#readme",
   "dependencies": {
     "inline-worker": "^1.1.0",


### PR DESCRIPTION
1. There's a shorter repository property for GitHub repositories, according to [npm docs](https://docs.npmjs.com/files/package.json#repository).
2. [normalize-package-data](https://github.com/npm/normalize-package-data#what-normalization-currently-entails) says bugs are needless if you're specified the repository.