### PR TITLE
Fix link to webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can find lots of examples at [showcases](https://whs-dev.surge.sh/examples/)
 * **ES2015+ based**
 * Extension system (plugins)
 * [asm.js](http://asmjs.org/) acceleration
-* [Webpack](webpack.js.org) friendly
+* [Webpack](https://webpack.js.org) friendly
 * Integrated [Three.js](https://threejs.org/) rendering engine
 * Work with Whitestorm.js and Three.js at the same time
 


### PR DESCRIPTION
Currently erroneously links to https://github.com/WhitestormJS/whitestorm.js/blob/dev/webpack.js.org

I suggest this should link to docs on usage docs for whitestorm + webpack instead.