### PR TITLE
Add stop() and play() methods for RenderingModule

### DIFF
--- a/src/modules/app/RenderingModule.js
+++ b/src/modules/app/RenderingModule.js
@@ -79,6 +79,14 @@ export class RenderingModule {
     canvas.style.height = '100%';
   }
 
+  stop() {
+    this.renderLoop.stop();
+  }
+
+  play() {
+    this.renderLoop.start();
+  }
+
   manager(manager) {
     this.renderLoop = this.integrateRenderer(
       manager.get('element'),


### PR DESCRIPTION
**This PR is related to issue #141**

**RenderingModule**
Added two methods to better control `renderingLoop`:
- `.stop()` - Stops `renderingLoop` execution.
- `.play()` - Resumes `renderingLoop` execution.