### PR TITLE
add click to list of patched events on element for app

### DIFF
--- a/src/modules/app/EventsPatchModule.js
+++ b/src/modules/app/EventsPatchModule.js
@@ -17,6 +17,7 @@ export class EventsPatchModule {
       'mouseup',
       'contextmenu',
       'mousedown',
+      'click',
       'wheel',
       'touchstart',
       'touchend',


### PR DESCRIPTION
noticed click event wasn't working for virtual mouse

found patched events list. noticed if i removed some, they didn't show up anymore. added `click` to array, and `component.on('click', cb)` worked.

you can see in current showcases site, in click example, there is no alert message on click