### PR TITLE
rm "module" parameter of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.0-beta.8",
   "description": "Framework for developing 3D web apps with physics.",
   "main": "build/whitestorm.js",
-  "module": "src/index.js",
   "scripts": {
     "version": "gulp build --prod && git add .",
     "test": "xo ./src/**/*.js && jest",


### PR DESCRIPTION
The "module" parameter will produce some bugs like this, when others require('whs'). Maybe, {"module": "src/index.js"} will be regarded as an entry of this package.

ERROR in ./~/_whs@2.0.0-beta.8@whs/src/core/Component.js
Module parse failed: C:\Users\75991\Desktop\projects\Marbles\node_modules\_whs@2.0.0-beta.8@whs\src\core\Component.js Unexpected token (7:18)
You may need an appropriate loader to handle this file type.
|
| class Component extends ModuleSystem {
|   static defaults = {
|     modules: [],
|     manager: true
 @ ./~/_whs@2.0.0-beta.8@whs/src/core/index.js 1:0-28
 @ ./~/_whs@2.0.0-beta.8@whs/src/index.js
 @ ./src/components/game/Game.js
 @ ./src/components/game/GameApp.js
 @ ./src/components/game/index.js
 @ ./src/components/Home.js
 @ ./src/components/index.js
 @ ./src/entry.js