### PR TITLE
Changed link from https to http in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ npm install whs
 * :dizzy: Automatization of rendering
 * 🆕 **ES2015+ based**
 * :large_blue_diamond: Extension system (modules)
-* :package: [Webpack](https://whsjs.io/Usage%20with%20webpack.html) friendly
+* :package: [Webpack](http://whsjs.io/Usage%20with%20webpack.html) friendly
 * ✔️ **Integrated [Three.js](https://threejs.org/) rendering engine**
 * :revolving_hearts: Work with whs.js and Three.js at the same time
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Three][three]][three-url]
 [![Build Status][travis]][travis-url]
 
-- [Documentation](http://whsjs.io/)
+- [Documentation](https://whs.io/)
 - [Examples](https://whs-dev.surge.sh/examples/)
 - [Donate / OpenCollective](https://opencollective.com/whitestormjs)
 
@@ -73,39 +73,39 @@ $ npm install whs
 ### Featured projects
 
 <a href="http://abdaily.surge.sh/4/">
-  <img src="http://whsjs.io/images/showcase/daily4.png" alt="http://abdaily.surge.sh/4/" width="30%" />
+  <img src="https://whs.io/images/showcase/daily4.png" alt="http://abdaily.surge.sh/4/" width="30%" />
 </a>
 
 <a href="http://abdaily.surge.sh/3/">
-  <img src="http://whsjs.io/images/showcase/daily3.png" alt="http://abdaily.surge.sh/3/" width="30%" />
+  <img src="https://whs.io/images/showcase/daily3.png" alt="http://abdaily.surge.sh/3/" width="30%" />
 </a>
 
 <a href="http://abdaily.surge.sh/2/">
-  <img src="http://whsjs.io/images/showcase/daily2.png" alt="http://abdaily.surge.sh/2/" width="30%" />
+  <img src="https://whs.io/images/showcase/daily2.png" alt="http://abdaily.surge.sh/2/" width="30%" />
 </a>
 
 <a href="http://abdaily.surge.sh/1/">
-  <img src="http://whsjs.io/images/showcase/daily1.png" alt="http://abdaily.surge.sh/1/" width="30%" />
+  <img src="https://whs.io/images/showcase/daily1.png" alt="http://abdaily.surge.sh/1/" width="30%" />
 </a>
 
 <a href="http://theroguepixel.com/">
-  <img src="http://whsjs.io/images/showcase/roguepixel.jpg" alt="http://theroguepixel.com/" width="30%" />
+  <img src="https://whs.io/images/showcase/roguepixel.jpg" alt="http://theroguepixel.com/" width="30%" />
 </a>
 
 <a href="http://supertiny.agency/">
-  <img src="http://whsjs.io/images/showcase/supertiny.jpg" alt="http://supertiny.agency/" width="30%" />
+  <img src="https://whs.io/images/showcase/supertiny.jpg" alt="http://supertiny.agency/" width="30%" />
 </a>
 
 <a href="https://alexbuzin.me/">
-  <img src="http://whsjs.io/images/showcase/alexbuzinme.jpg" alt="https://alexbuzin.me/" width="30%" />
+  <img src="https://whs.io/images/showcase/alexbuzinme.jpg" alt="https://alexbuzin.me/" width="30%" />
 </a>
 
 <a href="https://spatial.100shapes.com/">
-  <img src="http://whsjs.io/images/showcase/spatial.jpg" alt="https://spatial.100shapes.com/" width="30%" />
+  <img src="https://whs.io/images/showcase/spatial.jpg" alt="https://spatial.100shapes.com/" width="30%" />
 </a>
 
 <a href="http://plateaux.space/">
-  <img src="http://whsjs.io/images/showcase/plateux.jpg" alt="http://plateaux.space/" width="30%" />
+  <img src="https://whs.io/images/showcase/plateux.jpg" alt="http://plateaux.space/" width="30%" />
 </a>
 
 
@@ -118,7 +118,7 @@ $ npm install whs
 * :dizzy: Automatization of rendering
 * 🆕 **ES2015+ based**
 * :large_blue_diamond: Extension system (modules)
-* :package: [Webpack](http://whsjs.io/Usage%20with%20webpack.html) friendly
+* :package: [Webpack](https://whs.io/Usage%20with%20webpack.html) friendly
 * ✔️ **Integrated [Three.js](https://threejs.org/) rendering engine**
 * :revolving_hearts: Work with whs.js and Three.js at the same time
 


### PR DESCRIPTION
The link to the "usage with webpack" section incorrectly sends you to an https page with various warnings. changed to http instead.