### PR TITLE
Fix Welcome.md quick example

### DIFF
--- a/docs/data/Welcome.md
+++ b/docs/data/Welcome.md
@@ -18,7 +18,7 @@ const app = new WHS.App([
   new WHS.SceneModule(), // Create a new THREE.Scene and set it to app.
 
   new WHS.DefineModule('camera', new WHS.PerspectiveCamera({ // Apply a camera.
-    position: new Vector3(0, 0, 50)
+    position: new THREE.Vector3(0, 0, 50)
   })),
 
   new WHS.RenderingModule({bgColor: 0x162129}), // Apply THREE.WebGLRenderer


### PR DESCRIPTION
`Vector3` is actually `THREE.Vector3` -- took me a little bit to figure this one out.  So, it's now fixed for anyone else who comes along!