### PR TITLE
Enables ElementModule class to take empty params

### DIFF
--- a/types/modules/app/ElementModule.d.ts
+++ b/types/modules/app/ElementModule.d.ts
@@ -4,7 +4,7 @@ export class ElementModule {
    * @constructor Creates an element module.
    * @param container dom element to use as context for rendering
    */
-  constructor(container: HTMLElement);
+  constructor(container?: HTMLElement);
 
   /**
    * Creates a div element inside the container


### PR DESCRIPTION
This enables ElementModule constructor to take empty params as seen in most of the whs.js examples, so editor like vscode / sublime won't complain for syntax error.
reference: https://stackoverflow.com/a/12702786